### PR TITLE
Fixes for preview page.

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -310,7 +310,8 @@ const preview_success = (req, res, dataset_title, datalink, output) => {
 // and in this case we will fail gracefully
 const preview_fail = (req, res, dataset_title, datalink, error) => {
 
-  // Handle the possible missing datalink. Would be nicer if we
+  // Handle the possible missing datalink. Would be nicer if we had
+  // if expressions ...
   var url = ''
   var filename = ''
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -352,8 +352,7 @@ router.get('/preview-1/:datasetname/:datafileid', function (req, res) {
         .on('response', response => {
           if (response.headers['content-type'].indexOf('csv') == -1) {
             preview_fail(req, res, dataset_title, datalink,
-              //"We cannot show a preview of this file as it isn't in CSV format"
-              response.headers['content-type']
+              "We cannot show a preview of this file as it isn't in CSV format"
             )
           }
           else {

--- a/app/views/preview-1.html
+++ b/app/views/preview-1.html
@@ -10,7 +10,14 @@
   <div class="grid-row">
     <div class="column-full">
       <a href="/datasets/{{ datasetName }}" class="link-back">Back to dataset</a>
-      <h1 class="heading-large">{{ datasetTitle }}</h1>
+      <h1 class="heading-large">
+        {{ datasetTitle }}
+        {% if filename %}
+          <span class="heading-secondary">{{ filename }}</span>
+        {% endif %}
+      </h1>
+
+      {% if not error %}
       <p>You're previewing 5 rows out of the total 2000 in this file.</p>
       <details>
         <summary><span class="summary">How you can visualise this data</span></summary>
@@ -21,7 +28,12 @@
         <p>This data has dates in it, so you can visualise it as a time series to see evolution over time for example.</p>
         </div>
       </details>
-      <input class="button" type="submit" value="Download this file">
+      {% endif %}
+
+      {% if url %}
+        <a class="button" href="{{ url }}">Download this file</a>
+      {% endif%}
+
       <section class="preview">
         {% if error %}
           {{ error }}


### PR DESCRIPTION

Separates out the error and success cases for preview to make it
easier to manage.

Also:

* Handles error in csv generation
* Reduces the size of the csv to load before parse. There was a stat
  that I can't find about how the vast majority of CSV files are under
  11K or some other magic number.
* Passes the URL so users can download the file (even if we can't
  preview it).
* Resists the urge to remove all the camelCase
