### PR TITLE
Raise 404 on bad dataset name, rather than crash

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -267,8 +267,8 @@ function renderDataset(template, req, res, next) {
         .sort((g1, g2) => cmpStrings(g1.year, g2.year))
     }
 
-    if (esError) {
-      throw esError
+    if (esError || !result) {
+      res.status(404).send('Not found');
     } else {
       get_more_like_this(result, 3)
         .then( matches => {


### PR DESCRIPTION
Came across this when changing search indexes, so thought I'd fix it.

Still needs middleware to render the 404 page.